### PR TITLE
Changed include of mathlib in sKinematics header.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,18 +138,18 @@ target_link_libraries(iktest ${PROJECT_NAME} ${catkin_LIBRARIES})
 # )
 
 ## Mark executables and/or libraries for installation
-## install(TARGETS skinematics 
- ##  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  ## LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-   ##RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
- ##)
+ install(TARGETS skinematics 
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ )
 
 ## Mark cpp header files for installation
- ##install(DIRECTORY include/${PROJECT_NAME}/
-  ## DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-   ##FILES_MATCHING PATTERN "*.h"
-   ##PATTERN ".svn" EXCLUDE
-## )
+ install(DIRECTORY include/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN "*.h"
+   PATTERN ".svn" EXCLUDE
+ )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 # install(FILES

--- a/include/sKinematics.h
+++ b/include/sKinematics.h
@@ -1,7 +1,7 @@
 #ifndef __sKinematics_H__
 #define __sKinematics_H__
 
-#include "MathLib.h"
+#include <mathlib/MathLib.h>
 
 #define SINGULAR_TOLERANCE 0.001
 #define IK_TOLERANCE 0.000001


### PR DESCRIPTION
Enable installation of catkin libs to be used by (non-ros/catkin) downstream projects.
Since this lib depends on https://github.com/epfl-lasa/robot-toolkit/tree/master/packages/core/mathlib, the following pull-request needs to be merged first: https://github.com/epfl-lasa/robot-toolkit/pull/7.
